### PR TITLE
Add SQL query support in Ruby

### DIFF
--- a/lib/jquery_query_builder/evaluator.rb
+++ b/lib/jquery_query_builder/evaluator.rb
@@ -25,6 +25,10 @@ module JqueryQueryBuilder
     def object_matches_rules?(object)
       RuleGroup.new(parsed_rule_set).evaluate(object)
     end
+
+    def sql_query
+      RuleGroup.new(parsed_rule_set).sql_query
+    end
   end
 end
 

--- a/lib/jquery_query_builder/evaluator.rb
+++ b/lib/jquery_query_builder/evaluator.rb
@@ -9,13 +9,18 @@ require 'json'
 module JqueryQueryBuilder
   class Evaluator
     attr_accessor :parsed_rule_set
-    def initialize(rule_set)
+    attr_accessor :id_whitelist
+
+    def initialize(rule_set, id_whitelist: nil)
       if rule_set.is_a? String
         #assuming the json was passed in
         self.parsed_rule_set = JSON.parse(rule_set)
       else
         self.parsed_rule_set = rule_set
       end
+
+      # whitelist of ids to restrict the rules to just those within the whitelist
+      self.id_whitelist = id_whitelist
     end
 
     def get_matching_objects(objects)
@@ -23,11 +28,11 @@ module JqueryQueryBuilder
     end
 
     def object_matches_rules?(object)
-      RuleGroup.new(parsed_rule_set).evaluate(object)
+      RuleGroup.new(parsed_rule_set, id_whitelist: id_whitelist).evaluate(object)
     end
 
     def sql_query
-      RuleGroup.new(parsed_rule_set).sql_query
+      RuleGroup.new(parsed_rule_set, id_whitelist: id_whitelist).sql_query
     end
   end
 end

--- a/lib/jquery_query_builder/operators/begins_with.rb
+++ b/lib/jquery_query_builder/operators/begins_with.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left.start_with?(right)
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} LIKE ?)", "#{value}%"] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/begins_with.rb
+++ b/lib/jquery_query_builder/operators/begins_with.rb
@@ -7,7 +7,7 @@ module JqueryQueryBuilder
 
       def sql_query(id, value)
         # sanitize_sql_for_conditions is made public in Rails 5.2
-        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} LIKE ?)", "#{value}%"] )
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) LIKE LOWER(?))", "#{value}%"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/between.rb
+++ b/lib/jquery_query_builder/operators/between.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(input, bounds)
         input > bounds[0] && input < bounds[1]
       end
+
+      def sql_query(id, bounds)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} BETWEEN ? AND ?)", bounds[0], bounds[1]] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/contains.rb
+++ b/lib/jquery_query_builder/operators/contains.rb
@@ -8,7 +8,7 @@ module JqueryQueryBuilder
 
       def sql_query(id, value)
         # sanitize_sql_for_conditions is made public in Rails 5.2
-        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) LIKE LOWER(?)", "%#{value}%"] )
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) LIKE LOWER(?))", "%#{value}%"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/contains.rb
+++ b/lib/jquery_query_builder/operators/contains.rb
@@ -7,8 +7,8 @@ module JqueryQueryBuilder
       end
 
       def sql_query(id, value)
-        #sanitize_sql_for_conditions(["(where '?' = '?')", id, value])
-        "(#{id} like '%#{value}%')"
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} LIKE ?)", "%#{value}%"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/contains.rb
+++ b/lib/jquery_query_builder/operators/contains.rb
@@ -5,6 +5,11 @@ module JqueryQueryBuilder
         return false if left.nil?
         left.include?(right)
       end
+
+      def sql_query(id, value)
+        #sanitize_sql_for_conditions(["(where '?' = '?')", id, value])
+        "(#{id} like '%#{value}%')"
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/contains.rb
+++ b/lib/jquery_query_builder/operators/contains.rb
@@ -8,7 +8,7 @@ module JqueryQueryBuilder
 
       def sql_query(id, value)
         # sanitize_sql_for_conditions is made public in Rails 5.2
-        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} LIKE ?)", "%#{value}%"] )
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) LIKE LOWER(?)", "%#{value}%"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/ends_with.rb
+++ b/lib/jquery_query_builder/operators/ends_with.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left.end_with?(right)
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} LIKE ?)", "%#{value}"] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/ends_with.rb
+++ b/lib/jquery_query_builder/operators/ends_with.rb
@@ -7,7 +7,7 @@ module JqueryQueryBuilder
 
       def sql_query(id, value)
         # sanitize_sql_for_conditions is made public in Rails 5.2
-        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} LIKE ?)", "%#{value}"] )
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) LIKE LOWER(?))", "%#{value}"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/equal.rb
+++ b/lib/jquery_query_builder/operators/equal.rb
@@ -8,8 +8,8 @@ module JqueryQueryBuilder
       end
 
       def sql_query(id, value)
-        #sanitize_sql_for_conditions(["(where '?' = '?')", id, value])
-        "(#{id} = '#{value}')"
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} = ?)", value] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/equal.rb
+++ b/lib/jquery_query_builder/operators/equal.rb
@@ -1,8 +1,15 @@
+include ActiveRecord::Sanitization::ClassMethods
+
 module JqueryQueryBuilder
   module Operators
     class Equal
       def evaluate(left, right)
         left == right
+      end
+
+      def sql_query(id, value)
+        #sanitize_sql_for_conditions(["(where '?' = '?')", id, value])
+        "(#{id} = '#{value}')"
       end
     end
   end

--- a/lib/jquery_query_builder/operators/greater.rb
+++ b/lib/jquery_query_builder/operators/greater.rb
@@ -6,8 +6,8 @@ module JqueryQueryBuilder
       end
 
       def sql_query(id, value)
-        #sanitize_sql_for_conditions(["(where '?' = '?')", id, value])
-        "(#{id} > #{value.to_f})"
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} > ?)", value] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/greater.rb
+++ b/lib/jquery_query_builder/operators/greater.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left > right
       end
+
+      def sql_query(id, value)
+        #sanitize_sql_for_conditions(["(where '?' = '?')", id, value])
+        "(#{id} > #{value.to_f})"
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/greater_or_equal.rb
+++ b/lib/jquery_query_builder/operators/greater_or_equal.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left >= right
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} >= ?)", value] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/in.rb
+++ b/lib/jquery_query_builder/operators/in.rb
@@ -4,6 +4,12 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         right.include?(left)
       end
+
+      def sql_query(id, value)
+        value = value.join(', ') if value.is_a?(Array)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} IN(?))", value] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/is_empty.rb
+++ b/lib/jquery_query_builder/operators/is_empty.rb
@@ -4,6 +4,10 @@ module JqueryQueryBuilder
       def evaluate(input, value)
         input.blank?
       end
+
+      def sql_query(id, value)
+        "(#{id} = '')"
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/is_not_empty.rb
+++ b/lib/jquery_query_builder/operators/is_not_empty.rb
@@ -4,6 +4,10 @@ module JqueryQueryBuilder
       def evaluate(input, value)
         input.present?
       end
+
+      def sql_query(id, value)
+        "(#{id} != '')"
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/is_not_null.rb
+++ b/lib/jquery_query_builder/operators/is_not_null.rb
@@ -4,6 +4,10 @@ module JqueryQueryBuilder
       def evaluate(input, value)
         !input.nil?
       end
+
+      def sql_query(id, value)
+        "(#{id} IS NOT NULL)"
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/is_null.rb
+++ b/lib/jquery_query_builder/operators/is_null.rb
@@ -4,6 +4,10 @@ module JqueryQueryBuilder
       def evaluate(input, value)
         input.nil?
       end
+
+      def sql_query(id, value)
+        "(#{id} IS NULL)"
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/less.rb
+++ b/lib/jquery_query_builder/operators/less.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left < right
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} < ?)", value] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/less_or_equal.rb
+++ b/lib/jquery_query_builder/operators/less_or_equal.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left <= right
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} <= ?)", value] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/not_begins_with.rb
+++ b/lib/jquery_query_builder/operators/not_begins_with.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         !left.start_with?(right)
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT LIKE ?)", "%#{value}%"] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/not_between.rb
+++ b/lib/jquery_query_builder/operators/not_between.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(input, bounds)
         input <= bounds[0] || input >= bounds[1]
       end
+
+      def sql_query(id, bounds)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT BETWEEN ? AND ?)", bounds[0], bounds[1]] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/not_contains.rb
+++ b/lib/jquery_query_builder/operators/not_contains.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         !left.include?(right)
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT LIKE ?)", "%#{value}%"] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/not_contains.rb
+++ b/lib/jquery_query_builder/operators/not_contains.rb
@@ -7,7 +7,7 @@ module JqueryQueryBuilder
 
       def sql_query(id, value)
         # sanitize_sql_for_conditions is made public in Rails 5.2
-        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT LIKE ?)", "%#{value}%"] )
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) NOT LIKE LOWER(?))", "%#{value}%"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/not_ends_with.rb
+++ b/lib/jquery_query_builder/operators/not_ends_with.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         !left.end_with?(right)
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT LIKE ?)", "%#{value}"] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/not_ends_with.rb
+++ b/lib/jquery_query_builder/operators/not_ends_with.rb
@@ -7,7 +7,7 @@ module JqueryQueryBuilder
 
       def sql_query(id, value)
         # sanitize_sql_for_conditions is made public in Rails 5.2
-        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT LIKE ?)", "%#{value}"] )
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(LOWER(#{id}) NOT LIKE LOWER(?))", "%#{value}"] )
       end
     end
   end

--- a/lib/jquery_query_builder/operators/not_equal.rb
+++ b/lib/jquery_query_builder/operators/not_equal.rb
@@ -4,6 +4,11 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         left != right
       end
+
+      def sql_query(id, value)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} != ?)", value] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/operators/not_in.rb
+++ b/lib/jquery_query_builder/operators/not_in.rb
@@ -4,6 +4,12 @@ module JqueryQueryBuilder
       def evaluate(left, right)
         !right.include?(left)
       end
+
+      def sql_query(id, value)
+        value = value.join(', ') if value.is_a?(Array)
+        # sanitize_sql_for_conditions is made public in Rails 5.2
+        ApplicationRecord.send(:sanitize_sql_for_conditions, ["(#{id} NOT IN(?))", value] )
+      end
     end
   end
 end

--- a/lib/jquery_query_builder/rule.rb
+++ b/lib/jquery_query_builder/rule.rb
@@ -1,13 +1,20 @@
 module JqueryQueryBuilder
   class Rule
-    attr_accessor :id, :field, :type, :input, :operator, :value
-    def initialize(rule_hash)
+    attr_accessor :id, :field, :type, :input, :operator, :value, :id_whitelist
+    def initialize(rule_hash, id_whitelist: nil)
       self.id = rule_hash['id']
       self.field = rule_hash['field']
       self.type = rule_hash['type']
       self.input = rule_hash['input']
       self.operator = rule_hash['operator']
       self.value = rule_hash['value']
+      self.id_whitelist = id_whitelist
+    end
+
+    def whitelisted?
+      return true unless id_whitelist.present?
+
+      id_whitelist.include?(self.id)
     end
 
     def evaluate(object)

--- a/lib/jquery_query_builder/rule.rb
+++ b/lib/jquery_query_builder/rule.rb
@@ -14,6 +14,10 @@ module JqueryQueryBuilder
       get_operator.evaluate(get_input(object), get_value)
     end
 
+    def sql_query
+      get_operator.sql_query(self.id, get_value)
+    end
+
     def get_operator
       JqueryQueryBuilder::Operator.get_operator_class(operator).new
     end

--- a/lib/jquery_query_builder/rule_group.rb
+++ b/lib/jquery_query_builder/rule_group.rb
@@ -15,6 +15,22 @@ module JqueryQueryBuilder
       end
     end
 
+    def sql_query
+      queries = []
+      rules.each do |rule|
+        queries << get_rule_object(rule).sql_query
+      end
+
+      case condition
+      when "AND"
+        query = queries.join(' AND ')
+      when "OR"
+        query = queries.join(' OR ')
+      end
+
+      return query
+    end
+
     def get_rule_object(rule)
       if rule['rules'].present?
         RuleGroup.new(rule)

--- a/lib/jquery_query_builder/rule_group.rb
+++ b/lib/jquery_query_builder/rule_group.rb
@@ -50,7 +50,7 @@ module JqueryQueryBuilder
         when "OR"
           query_string = queries.join(' OR ')
         end
-        query_string = "(#{query})"   # add parens for groups
+        query_string = "(#{query_string})"   # add parens for groups
       end
 
       return query_string

--- a/lib/jquery_query_builder/rule_group.rb
+++ b/lib/jquery_query_builder/rule_group.rb
@@ -1,41 +1,71 @@
 module JqueryQueryBuilder
   class RuleGroup
-    attr_accessor :condition, :rules
-    def initialize(rule_group_hash)
+    attr_accessor :condition, :rules, :id_whitelist
+    def initialize(rule_group_hash, id_whitelist: nil)
       self.condition = rule_group_hash['condition']
       self.rules = rule_group_hash['rules']
+      self.id_whitelist = id_whitelist
     end
 
     def evaluate(object)
       case condition
       when "AND"
-        rules.all?{|rule| get_rule_object(rule).evaluate(object) }
+        rules.all? do |rule|
+          rule_obj = get_rule_object(rule)
+          if rule_obj.whitelisted?
+            rule_obj.evaluate(object)
+          else
+            true  # ignore non whitelisted rule
+          end
+        end
       when "OR"
-        rules.any?{|rule| get_rule_object(rule).evaluate(object) }
+        rules.any? do |rule|
+          rule_obj = get_rule_object(rule)
+          if rule_obj.whitelisted?
+            rule_obj.evaluate(object)
+          else
+            false  # ignore non whitelisted rule
+          end
+        end
       end
     end
 
     def sql_query
       queries = []
       rules.each do |rule|
-        queries << get_rule_object(rule).sql_query
+        rule_object = get_rule_object(rule)
+        # skip the conditional if the rule is not whitelisted
+        sub_query = rule_object.sql_query if rule_object.whitelisted?
+        queries << sub_query if sub_query  # query can be nil if all rules are rejected
       end
 
-      case condition
-      when "AND"
-        query = queries.join(' AND ')
-      when "OR"
-        query = queries.join(' OR ')
+      if queries.empty?
+        query_string = nil
+      elsif queries.length == 1
+        query_string = queries[0]
+      elsif queries.length > 1
+        case condition
+        when "AND"
+          query_string = queries.join(' AND ')
+        when "OR"
+          query_string = queries.join(' OR ')
+        end
+        query_string = "(#{query})"   # add parens for groups
       end
 
-      return query
+      return query_string
+    end
+
+    def whitelisted?
+      # rule groups are always whitelisted, only rules can fail
+      true
     end
 
     def get_rule_object(rule)
       if rule['rules'].present?
-        RuleGroup.new(rule)
+        RuleGroup.new(rule, id_whitelist: id_whitelist)
       else
-        Rule.new(rule)
+        Rule.new(rule, id_whitelist: id_whitelist)
       end
     end
   end


### PR DESCRIPTION
new 'sql_query' function that will return a raw SQL query.    

- Uses Rails 'sanitize_sql_for_conditions' to prevent SQL injection.   
- Adds an 'id_whitelist' to limit searches to just the id fields that are approved.  This is similar to hard params