### PR TITLE
Upgrade JSON gem to >= 2.3.0

### DIFF
--- a/jquery_query_builder-rails.gemspec
+++ b/jquery_query_builder-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{lib,vendor}/**/*"] + ["LICENSE.txt", "CODE_OF_CONDUCT.md", "README.md"]
 
   spec.add_dependency "railties", ">= 3.1"
-  spec.add_dependency "json", ">= 1.8.3"
+  spec.add_dependency "json", ">= 2.3.0"
   spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Upgrades JSON gem dependency to >= 2.3.0, which patches an [Unsafe Object Creation Vulnerability](https://github.com/advisories/GHSA-jphg-qwrw-7w9g)